### PR TITLE
Reference Microsoft.AspNetCore.App for DependencyInjection.

### DIFF
--- a/pkg/Elskom.Sdk.App.Ref/Elskom.Sdk.App.Ref.sfxproj
+++ b/pkg/Elskom.Sdk.App.Ref/Elskom.Sdk.App.Ref.sfxproj
@@ -18,11 +18,14 @@
     <SkipValidatePackage>true</SkipValidatePackage>
     <GenerateInstallers>true</GenerateInstallers>
     <IncludeSymbols>false</IncludeSymbols>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="7.0.0-beta.21512.6" />
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.NETCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="../../ref/GitInformation/GitInformation.csproj" />
     <ProjectReference Include="../../ref/Common/Common.csproj" />
     <!-- zlib.managed has a zlib compression regression that needs fixed. -->

--- a/pkg/Elskom.Sdk.App.Runtime/Elskom.Sdk.App.sfxproj
+++ b/pkg/Elskom.Sdk.App.Runtime/Elskom.Sdk.App.sfxproj
@@ -17,11 +17,14 @@
     <SkipValidatePackage>true</SkipValidatePackage>
     <GenerateInstallers>true</GenerateInstallers>
     <IncludeSymbols>false</IncludeSymbols>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="7.0.0-beta.21512.6" />
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.NETCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="../../src/GitInformation/GitInformation.csproj" />
     <ProjectReference Include="../../src/Common/Common.csproj" />
     <!-- zlib.managed has a zlib compression regression that needs fixed. -->

--- a/ref/GenericPluginLoader/Directory.Packages.props
+++ b/ref/GenericPluginLoader/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../ZipAssembly/ZipAssembly.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="*-*" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Import Project="../Directory.Packages.props" />

--- a/ref/PluginUpdateCheck/Directory.Packages.props
+++ b/ref/PluginUpdateCheck/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Common/Common.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="*-*" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Import Project="../Directory.Packages.props" />

--- a/src/GenericPluginLoader/Directory.Packages.props
+++ b/src/GenericPluginLoader/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../ZipAssembly/ZipAssembly.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="*-*" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Import Project="../Directory.Packages.props" />

--- a/src/PluginUpdateCheck/Directory.Packages.props
+++ b/src/PluginUpdateCheck/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Common/Common.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="*-*" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="IDisposableGenerator" Version="*-*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; compile; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This makes it a lot easier as then the DependencyInjection package (being the same version as the one it it's framework) can be replaced and get free updates from the one in the framework. So to prevent possible security issues later, always use the one from the framework instead of the package version.

# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [x] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [x] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [x] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

<!-- A brief description of what this fixes or what this adds should be here. -->
