### PR TITLE
Add an VSConfig.

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.NuGet",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.Component.MSBuild",
+    "Microsoft.NetCore.Component.Runtime.6.0",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.Net.Component.4.7.2.TargetingPack",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.VisualStudio.Component.FSharp",
+    "Microsoft.ComponentGroup.ClickOnce.Publish",
+    "Microsoft.NetCore.Component.DevelopmentTools",
+    "Microsoft.VisualStudio.Component.SQL.CLR",
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.Net.Component.4.8.SDK",
+    "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.Component.ClickOnce",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
+    "Component.Microsoft.Web.LibraryManager",
+    "Component.Microsoft.WebTools.BrowserLink.WebLivePreview",
+    "Microsoft.Net.Component.4.8.TargetingPack",
+    "Microsoft.Net.ComponentGroup.4.8.DeveloperTools",
+    "Microsoft.VisualStudio.ComponentGroup.AdditionalWebProjectTemplates",
+    "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.CMake"
+  ]
+}


### PR DESCRIPTION
Now it should be that when the sln is opened without the needed components that VS should offer to now install them.

# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [x] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [x] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [x] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

<!-- A brief description of what this fixes or what this adds should be here. -->
