### PR TITLE
Fixed plugin loader to prefer loading RID specific plugins after non-rid specific ones are loaded.

### DIFF
--- a/ref/Common/Common/RuntimeHelpers.cs
+++ b/ref/Common/Common/RuntimeHelpers.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2018-2022, Els_kom org.
+// https://github.com/Elskom/
+// All rights reserved.
+// license: MIT, see LICENSE for more details.
+
+namespace Elskom.Generic.Libs;
+
+/// <summary>
+/// Internal Runtime Helpers.
+/// </summary>
+public static class RuntimeHelpers
+{
+    /// <summary>
+    /// Gets the runtime identifier for the current process,
+    /// that is it transforms the operating system and the process architecture
+    /// of the current process into an valid runtime identifier that the .NET SDK has.
+    /// </summary>
+    /// <returns>
+    /// An Runtime Identifier string, or null if it cannot be converted into an runtime identifier.
+    /// </returns>
+    public static string GetCurrentRuntimeIdentifier()
+        => throw null;
+}

--- a/src/Common/Common/RuntimeHelpers.cs
+++ b/src/Common/Common/RuntimeHelpers.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) 2018-2022, Els_kom org.
+// https://github.com/Elskom/
+// All rights reserved.
+// license: MIT, see LICENSE for more details.
+
+namespace Elskom.Generic.Libs;
+
+/// <summary>
+/// Internal Runtime Helpers.
+/// </summary>
+public static class RuntimeHelpers
+{
+    /// <summary>
+    /// Gets the runtime identifier for the current process,
+    /// that is it transforms the operating system and the process architecture
+    /// of the current process into an valid runtime identifier that the .NET SDK has.
+    /// </summary>
+    /// <returns>
+    /// An Runtime Identifier string, or null if it cannot be converted into an runtime identifier.
+    /// </returns>
+    public static string GetCurrentRuntimeIdentifier()
+        => (
+
+            // Desktop Operating Systems.
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsLinux(),
+            OperatingSystem.IsMacOS(),
+            OperatingSystem.IsMacCatalyst(),
+            OperatingSystem.IsFreeBSD(),
+
+            // Phone Operting Systems.
+            OperatingSystem.IsAndroid(),
+            OperatingSystem.IsIOS(),
+            OperatingSystem.IsWatchOS(),
+            OperatingSystem.IsTvOS(),
+
+            // Web Browser.
+            OperatingSystem.IsBrowser()) switch
+        {
+            (true, false, false, false, false, false, false, false, false, false) => $"win-{RuntimeInformation.ProcessArchitecture}",
+            (false, true, false, false, false, false, false, false, false, false) => $"linux-{RuntimeInformation.ProcessArchitecture}",
+            (false, false, true, false, false, false, false, false, false, false) => $"osx-{RuntimeInformation.ProcessArchitecture}",
+            (false, false, false, true, false, false, false, false, false, false) => $"maccatalyst-{RuntimeInformation.ProcessArchitecture}",
+            (false, false, false, false, true, false, false, false, false, false) => $"freebsd-{RuntimeInformation.ProcessArchitecture}",
+            (false, false, false, false, false, true, false, false, false, false) => $"android-{RuntimeInformation.ProcessArchitecture}",
+            (false, false, false, false, false, false, true, false, false, false) => "ios-arm64",
+            (false, false, false, false, false, false, false, false, true, false) => $"tvos-{RuntimeInformation.ProcessArchitecture}",
+            (false, false, false, false, false, false, false, false, false, true) => "browser-wasm",
+
+            // The WatchOS operating system does not seem to have an RID.
+            _ => null,
+        };
+}

--- a/src/Common/Directory.Build.targets
+++ b/src/Common/Directory.Build.targets
@@ -17,6 +17,7 @@
       <_Parameter1>Elskom.PluginFramework,PublicKey=$(SnkPublicKey)</_Parameter1>
     </AssemblyAttribute>
     <Using Include="System.Diagnostics" />
+    <Using Include="System.Runtime.InteropServices" />
     <Using Include="System.Text" /> 
   </ItemGroup>
 

--- a/src/GenericPluginLoader/GenericPluginLoader/GenericPluginLoader.cs
+++ b/src/GenericPluginLoader/GenericPluginLoader/GenericPluginLoader.cs
@@ -53,7 +53,16 @@ public sealed class GenericPluginLoader
         List<string>? dllFileNames = null;
         if (Directory.Exists(path))
         {
-            dllFileNames = Directory.EnumerateFiles(path, "*.dll").ToList();
+            // First search for plugins under the any (universal) runtime identifier.
+            dllFileNames = Directory.EnumerateFiles(
+                    $"{path}{Path.DirectorySeparatorChar}any",
+                    "*.dll").ToList();
+
+            // Next, search for plugins under the current process's runtime identifier.
+            // This is needed as native C++ plugins are runtime identifier (and cpu) specific.
+            dllFileNames.AddRange(Directory.EnumerateFiles(
+                $"{path}{Path.DirectorySeparatorChar}{RuntimeHelpers.GetCurrentRuntimeIdentifier()}",
+                "*.dll"));
         }
 
         // try to load from a zip as well if plugins are installed in both places.
@@ -87,7 +96,11 @@ public sealed class GenericPluginLoader
                 {
                     foreach (var entry in zipFile.Entries)
                     {
-                        filesInZip.Add(entry.FullName, zipFile.Entries.IndexOf(entry));
+                        if (entry.FullName.Contains(RuntimeHelpers.GetCurrentRuntimeIdentifier(), StringComparison.OrdinalIgnoreCase)
+                            || entry.FullName.Contains("any", StringComparison.OrdinalIgnoreCase))
+                        {
+                            filesInZip.Add(entry.FullName, zipFile.Entries.IndexOf(entry));
+                        }
                     }
                 }
 


### PR DESCRIPTION
This will fix the problem when trying to load plugins made in C++ /CLR.

# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [x] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [x] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [x] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

<!-- A brief description of what this fixes or what this adds should be here. -->
